### PR TITLE
Add !liveodds command to display live footy match betting odds

### DIFF
--- a/broiestbot/bot.py
+++ b/broiestbot/bot.py
@@ -25,6 +25,7 @@ from broiestbot.commands import (
     find_movie,
     footy_all_upcoming_fixtures,
     footy_live_fixtures,
+    footy_live_odds,
     footy_stats_for_live_fixtures,
     footy_team_lineups,
     footy_today_fixtures_odds,
@@ -194,6 +195,8 @@ class Bot(RoomManager):
             return footy_stats_for_live_fixtures(room.room_name.lower(), user_name)
         elif cmd_type == "footystats" and room and user_name:
             return footy_stats_for_live_fixtures(room.room_name.lower(), user_name)
+        elif cmd_type == "liveodds" and user_name:
+            return footy_live_odds(user_name)
         elif cmd_type == "todayfixtures" and room and user_name:
             return today_upcoming_fixtures(room.room_name.lower(), user_name)
         elif cmd_type == "goldenboot":

--- a/broiestbot/commands/__init__.py
+++ b/broiestbot/commands/__init__.py
@@ -16,6 +16,7 @@ from .footy import (
     fetch_fox_fixtures,
     footy_all_upcoming_fixtures,
     footy_live_fixtures,
+    footy_live_odds,
     footy_stats_for_live_fixtures,
     footy_team_lineups,
     footy_today_fixtures_odds,

--- a/broiestbot/commands/footy/__init__.py
+++ b/broiestbot/commands/footy/__init__.py
@@ -1,6 +1,7 @@
 from .goldenboot import all_leagues_golden_boot, epl_golden_boot
 from .lineups import footy_team_lineups
 from .live import footy_live_fixtures
+from .liveodds import footy_live_odds
 from .odds import get_today_footy_odds_for_league
 from .predicts import footy_today_fixtures_odds
 from .standings import league_table_standings, mls_standings

--- a/broiestbot/commands/footy/liveodds.py
+++ b/broiestbot/commands/footy/liveodds.py
@@ -1,0 +1,122 @@
+"""Live betting odds for currently-active footy fixtures."""
+
+from typing import Optional
+
+import requests
+from emoji import emojize
+from logger import LOGGER
+from requests.exceptions import HTTPError
+
+from config import (
+    FOOTY_HTTP_HEADERS,
+    FOOTY_LIVE_ODDS_ENDPOINT,
+    FOOTY_LIVE_ODDS_LEAGUES,
+    HTTP_REQUEST_TIMEOUT,
+)
+
+from .live import fetch_live_fixtures
+from .util import abbreviate_team_name
+
+
+def footy_live_odds(username: str) -> str:
+    """
+    Fetch and display live betting odds for all active fixtures.
+
+    :param str username: Name of user who triggered the command.
+
+    :returns: str
+    """
+    all_odds = "\n\n\n"
+    i = 0
+    for league_name, league_id in FOOTY_LIVE_ODDS_LEAGUES.items():
+        league_odds = footy_live_odds_per_league(league_id, league_name, username)
+        if league_odds is not None and i < 6:
+            i += 1
+            all_odds += league_odds + "\n"
+    if all_odds == "\n\n\n":
+        return emojize(":warning: No live odds available :warning:", language="en")
+    return all_odds
+
+
+def footy_live_odds_per_league(league_id: int, league_name: str, username: str) -> Optional[str]:
+    """
+    Fetch and format live 1X2 odds for all active fixtures in a given league.
+
+    :param int league_id: ID of footy league/cup.
+    :param str league_name: Display name of the league.
+    :param str username: Name of user who triggered the command.
+
+    :returns: Optional[str]
+    """
+    try:
+        fixtures = fetch_live_fixtures(league_id, username)
+        if not fixtures:
+            return None
+
+        live_odds = fetch_live_odds_per_league(league_id)
+        if not live_odds:
+            return None
+
+        odds_by_fixture = {}
+        for entry in live_odds:
+            fixture_id = entry["fixture"]["id"]
+            for bet in entry.get("odds", []):
+                if bet.get("name") == "Match Winner":
+                    odds_by_fixture[fixture_id] = bet.get("values", [])
+
+        league_output = emojize(f":soccer_ball: :moneybag: <b>{league_name}</b>\n", language="en")
+        found = False
+        for fixture in fixtures:
+            fixture_id = fixture["fixture"]["id"]
+            if fixture_id not in odds_by_fixture:
+                continue
+            found = True
+            home_team = abbreviate_team_name(fixture["teams"]["home"].get("name", ""))
+            away_team = abbreviate_team_name(fixture["teams"]["away"].get("name", ""))
+            home_score = fixture["goals"].get("home", "")
+            away_score = fixture["goals"].get("away", "")
+            elapsed = fixture["fixture"]["status"].get("elapsed", "")
+            values = odds_by_fixture[fixture_id]
+            home_odd = next((v["odd"] for v in values if v["value"] == "Home"), "N/A")
+            draw_odd = next((v["odd"] for v in values if v["value"] == "Draw"), "N/A")
+            away_odd = next((v["odd"] for v in values if v["value"] == "Away"), "N/A")
+            league_output += (
+                f"<b>{away_team} {away_score} @ {home_team} {home_score}</b> <i>({elapsed}')</i>\n"
+                f"{home_team}: {home_odd}  Draw: {draw_odd}  {away_team}: {away_odd}\n\n"
+            )
+
+        if found:
+            return league_output
+        return None
+    except HTTPError as e:
+        LOGGER.exception(f"HTTPError while fetching live footy odds: {e.response.content}")
+    except KeyError as e:
+        LOGGER.exception(f"KeyError while fetching live footy odds: {e}")
+    except Exception as e:
+        LOGGER.exception(f"Unexpected error when fetching live footy odds: {e}")
+
+
+def fetch_live_odds_per_league(league_id: int) -> Optional[list]:
+    """
+    Fetch live 1X2 odds for all active fixtures in a given league.
+
+    :param int league_id: ID of footy league/cup.
+
+    :returns: Optional[list]
+    """
+    try:
+        params = {"league": league_id, "bet": 1}
+        resp = requests.get(
+            FOOTY_LIVE_ODDS_ENDPOINT,
+            headers=FOOTY_HTTP_HEADERS,
+            params=params,
+            timeout=HTTP_REQUEST_TIMEOUT,
+        )
+        if resp.status_code == 200:
+            return resp.json().get("response")
+    except HTTPError as e:
+        LOGGER.exception(f"HTTPError while fetching live footy odds: {e.response.content}")
+    except KeyError as e:
+        LOGGER.exception(f"KeyError while fetching live footy odds: {e}")
+    except Exception as e:
+        LOGGER.exception(f"Unexpected error when fetching live footy odds: {e}")

--- a/broiestbot/commands/footy/liveodds.py
+++ b/broiestbot/commands/footy/liveodds.py
@@ -53,18 +53,23 @@ def footy_live_odds_per_league(league_id: int, league_name: str, username: str) 
         if not fixtures:
             return None
 
-        live_odds = fetch_live_odds_per_league(league_id)
-        if not live_odds:
+        odds_by_fixture = {}
+        for fixture in fixtures:
+            fixture_id = fixture["fixture"]["id"]
+            fixture_odds = fetch_live_odds_per_fixture(fixture_id)
+            if not fixture_odds:
+                continue
+            for entry in fixture_odds:
+                for bet in entry.get("odds", []):
+                    if bet.get("name") == "Fulltime Result":
+                        odds_by_fixture[fixture_id] = bet.get("values", [])
+                        break
+
+        if not odds_by_fixture:
+            LOGGER.warning(f"No live odds found for any fixture in {league_name}")
             return None
 
-        odds_by_fixture = {}
-        for entry in live_odds:
-            fixture_id = entry["fixture"]["id"]
-            for bet in entry.get("odds", []):
-                if bet.get("name") == "Match Winner":
-                    odds_by_fixture[fixture_id] = bet.get("values", [])
-
-        league_output = emojize(f":soccer_ball: :moneybag: <b>{league_name}</b>\n", language="en")
+        league_output = emojize(f"<b>{league_name}</b>\n", language="en")
         found = False
         for fixture in fixtures:
             fixture_id = fixture["fixture"]["id"]
@@ -82,30 +87,30 @@ def footy_live_odds_per_league(league_id: int, league_name: str, username: str) 
             away_odd = next((v["odd"] for v in values if v["value"] == "Away"), "N/A")
             league_output += (
                 f"<b>{away_team} {away_score} @ {home_team} {home_score}</b> <i>({elapsed}')</i>\n"
-                f"{home_team}: {home_odd}  Draw: {draw_odd}  {away_team}: {away_odd}\n\n"
+                f"{home_team}: {home_odd} \n Draw: {draw_odd} \n {away_team}: {away_odd}\n\n"
             )
-
+ 
         if found:
             return league_output
         return None
     except HTTPError as e:
-        LOGGER.exception(f"HTTPError while fetching live footy odds: {e.response.content}")
+        LOGGER.exception(f"HTTPError while fetching live footy odds: {getattr(e.response, 'content', e)}")
     except KeyError as e:
         LOGGER.exception(f"KeyError while fetching live footy odds: {e}")
     except Exception as e:
         LOGGER.exception(f"Unexpected error when fetching live footy odds: {e}")
 
 
-def fetch_live_odds_per_league(league_id: int) -> Optional[list]:
+def fetch_live_odds_per_fixture(fixture_id: int) -> Optional[list]:
     """
-    Fetch live 1X2 odds for all active fixtures in a given league.
+    Fetch live 1X2 odds for a specific fixture.
 
-    :param int league_id: ID of footy league/cup.
+    :param int fixture_id: ID of a live fixture.
 
     :returns: Optional[list]
     """
     try:
-        params = {"league": league_id, "bet": 1}
+        params = {"fixture": fixture_id}
         resp = requests.get(
             FOOTY_LIVE_ODDS_ENDPOINT,
             headers=FOOTY_HTTP_HEADERS,
@@ -113,10 +118,13 @@ def fetch_live_odds_per_league(league_id: int) -> Optional[list]:
             timeout=HTTP_REQUEST_TIMEOUT,
         )
         if resp.status_code == 200:
-            return resp.json().get("response")
+            data = resp.json().get("response", [])
+            if not data:
+                LOGGER.warning(f"Empty live odds response for fixture {fixture_id}: {resp.text[:300]}")
+            return data
+        LOGGER.warning(f"Non-200 live odds response for fixture {fixture_id}: {resp.status_code} {resp.text[:300]}")
     except HTTPError as e:
-        LOGGER.exception(f"HTTPError while fetching live footy odds: {e.response.content}")
-    except KeyError as e:
-        LOGGER.exception(f"KeyError while fetching live footy odds: {e}")
+        LOGGER.exception(f"HTTPError fetching live odds for fixture {fixture_id}: {getattr(e.response, 'content', e)}")
     except Exception as e:
-        LOGGER.exception(f"Unexpected error when fetching live footy odds: {e}")
+        LOGGER.exception(f"Error fetching live odds for fixture {fixture_id}: {e}")
+    return None

--- a/broiestbot/commands/footy/tests/conftest.py
+++ b/broiestbot/commands/footy/tests/conftest.py
@@ -1,0 +1,75 @@
+"""Shared fixtures for footy command tests."""
+
+from typing import List
+
+import pytest
+
+
+@pytest.fixture
+def live_fixture() -> dict:
+    """Single live World Cup fixture as returned by /v3/fixtures?live=all."""
+    return {
+        "fixture": {
+            "id": 1489392,
+            "timezone": "UTC",
+            "timestamp": 1750000000,
+            "status": {"long": "Second Half", "short": "2H", "elapsed": 67},
+            "venue": {"name": "Levi's Stadium", "city": "Santa Clara"},
+        },
+        "league": {"id": 1, "name": "World Cup", "country": "World", "season": 2026},
+        "teams": {
+            "home": {"id": 10, "name": "United States", "winner": None},
+            "away": {"id": 24, "name": "Portugal", "winner": None},
+        },
+        "goals": {"home": 1, "away": 1},
+        "score": {"halftime": {"home": 0, "away": 1}, "fulltime": {"home": None, "away": None}},
+    }
+
+
+@pytest.fixture
+def live_odds_response_fixture(live_fixture) -> List[dict]:
+    """
+    Response from /v3/odds/live?fixture=1489392.
+    Bets are in a top-level "odds" array; the live equivalent of "Match Winner"
+    is "Fulltime Result" (id=59). "Match Winner" (id=1) does not appear in live odds.
+    """
+    return [
+        {
+            "fixture": {"id": live_fixture["fixture"]["id"]},
+            "league": live_fixture["league"],
+            "update": "2026-06-20T20:24:00+00:00",
+            "odds": [
+                {
+                    "id": 59,
+                    "name": "Fulltime Result",
+                    "values": [
+                        {"value": "Home", "odd": "3.20", "handicap": None, "main": None, "suspended": False},
+                        {"value": "Draw", "odd": "3.10", "handicap": None, "main": None, "suspended": False},
+                        {"value": "Away", "odd": "2.25", "handicap": None, "main": None, "suspended": False},
+                    ],
+                }
+            ],
+        }
+    ]
+
+
+@pytest.fixture
+def live_odds_no_fulltime_result(live_fixture) -> List[dict]:
+    """Response that contains odds but no 'Fulltime Result' bet — should yield no parsed output."""
+    return [
+        {
+            "fixture": {"id": live_fixture["fixture"]["id"]},
+            "league": live_fixture["league"],
+            "update": "2026-06-20T20:24:00+00:00",
+            "odds": [
+                {
+                    "id": 20,
+                    "name": "Match Corners",
+                    "values": [
+                        {"value": "Over", "odd": "2.625", "handicap": "8"},
+                        {"value": "Under", "odd": "1.833", "handicap": "8"},
+                    ],
+                }
+            ],
+        }
+    ]

--- a/broiestbot/commands/footy/tests/test_liveodds.py
+++ b/broiestbot/commands/footy/tests/test_liveodds.py
@@ -1,0 +1,144 @@
+"""Tests for live footy odds parsing logic."""
+
+from typing import List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from broiestbot.commands.footy.liveodds import fetch_live_odds_per_fixture, footy_live_odds_per_league
+
+
+# ---------------------------------------------------------------------------
+# fetch_live_odds_per_fixture
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_live_odds_per_fixture_returns_response(live_odds_response_fixture):
+    """fetch_live_odds_per_fixture returns the response list on HTTP 200."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"response": live_odds_response_fixture}
+
+    with patch("broiestbot.commands.footy.liveodds.requests.get", return_value=mock_resp):
+        result = fetch_live_odds_per_fixture(1489392)
+
+    assert result == live_odds_response_fixture
+
+
+def test_fetch_live_odds_per_fixture_returns_none_on_non_200():
+    """fetch_live_odds_per_fixture returns None for non-200 status codes."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 403
+    mock_resp.text = "Forbidden"
+
+    with patch("broiestbot.commands.footy.liveodds.requests.get", return_value=mock_resp):
+        result = fetch_live_odds_per_fixture(1489392)
+
+    assert result is None
+
+
+def test_fetch_live_odds_per_fixture_returns_empty_list_on_empty_response():
+    """fetch_live_odds_per_fixture returns [] when the API reports 200 but no odds exist."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"response": []}
+    mock_resp.text = '{"response": []}'
+
+    with patch("broiestbot.commands.footy.liveodds.requests.get", return_value=mock_resp):
+        result = fetch_live_odds_per_fixture(1489392)
+
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# bookmakers[].bets parsing — the key bug
+# ---------------------------------------------------------------------------
+
+
+def test_fulltime_result_is_parsed_from_top_level_odds(live_fixture, live_odds_response_fixture):
+    """
+    The live odds API returns bets in a top-level 'odds' array.
+    'Fulltime Result' (id=59) is the live equivalent of 'Match Winner' — verify it parses correctly.
+    """
+    odds_by_fixture = {}
+    fixture_id = live_fixture["fixture"]["id"]
+
+    for entry in live_odds_response_fixture:
+        for bet in entry.get("odds", []):
+            if bet.get("name") == "Fulltime Result":
+                odds_by_fixture[fixture_id] = bet.get("values", [])
+                break
+
+    assert fixture_id in odds_by_fixture
+    values = odds_by_fixture[fixture_id]
+    assert len(values) == 3
+    home_odd = next((v["odd"] for v in values if v["value"] == "Home"), None)
+    draw_odd = next((v["odd"] for v in values if v["value"] == "Draw"), None)
+    away_odd = next((v["odd"] for v in values if v["value"] == "Away"), None)
+    assert home_odd == "3.20"
+    assert draw_odd == "3.10"
+    assert away_odd == "2.25"
+
+
+def test_missing_fulltime_result_yields_no_odds(live_fixture, live_odds_no_fulltime_result):
+    """Response with no 'Fulltime Result' bet produces an empty odds_by_fixture dict."""
+    odds_by_fixture = {}
+    fixture_id = live_fixture["fixture"]["id"]
+
+    for entry in live_odds_no_fulltime_result:
+        for bet in entry.get("odds", []):
+            if bet.get("name") == "Fulltime Result":
+                odds_by_fixture[fixture_id] = bet.get("values", [])
+                break
+
+    assert fixture_id not in odds_by_fixture
+
+
+# ---------------------------------------------------------------------------
+# footy_live_odds_per_league — integration-style
+# ---------------------------------------------------------------------------
+
+
+def test_footy_live_odds_per_league_formats_output(live_fixture, live_odds_response_fixture):
+    """footy_live_odds_per_league returns a formatted string with team names and odds."""
+    with (
+        patch(
+            "broiestbot.commands.footy.liveodds.fetch_live_fixtures",
+            return_value=[live_fixture],
+        ),
+        patch(
+            "broiestbot.commands.footy.liveodds.fetch_live_odds_per_fixture",
+            return_value=live_odds_response_fixture,
+        ),
+    ):
+        result = footy_live_odds_per_league(1, "WORLD CUP", "testuser")
+
+    assert result is not None
+    assert "3.20" in result
+    assert "3.10" in result
+    assert "2.25" in result
+
+
+def test_footy_live_odds_per_league_returns_none_when_no_fixtures():
+    """footy_live_odds_per_league returns None when there are no live fixtures."""
+    with patch("broiestbot.commands.footy.liveodds.fetch_live_fixtures", return_value=[]):
+        result = footy_live_odds_per_league(1, "WORLD CUP", "testuser")
+
+    assert result is None
+
+
+def test_footy_live_odds_per_league_returns_none_when_no_odds(live_fixture):
+    """footy_live_odds_per_league returns None when the odds API returns nothing."""
+    with (
+        patch(
+            "broiestbot.commands.footy.liveodds.fetch_live_fixtures",
+            return_value=[live_fixture],
+        ),
+        patch(
+            "broiestbot.commands.footy.liveodds.fetch_live_odds_per_fixture",
+            return_value=[],
+        ),
+    ):
+        result = footy_live_odds_per_league(1, "WORLD CUP", "testuser")
+
+    assert result is None

--- a/config.py
+++ b/config.py
@@ -321,6 +321,7 @@ FOOTY_STANDINGS_ENDPOINT = f"{FOOTY_BASE_URL}/standings"
 FOOTY_FIXTURE_STATS_ENDPOINT = f"{FOOTY_BASE_URL}/fixtures/statistics"
 FOOTY_ODDS_ENDPOINT = "https://odds.p.rapidapi.com/v1/odds"
 FOOTY_ODDS_ENDPOINT_2 = "https://api-football-v1.p.rapidapi.com/v3/odds"
+FOOTY_LIVE_ODDS_ENDPOINT = f"{FOOTY_BASE_URL}/odds/live"
 FOOTY_XI_ENDPOINT = "https://api-football-v1.p.rapidapi.com/v3/fixtures/lineups"
 FOOTY_PREDICTS_ENDPOINT = "https://api-football-v1.p.rapidapi.com/v3/predictions"
 FOOTY_HTTP_HEADERS = {


### PR DESCRIPTION
Fetches live 1X2 (Match Winner) odds from api-football-v1 for all currently-active fixtures across configured leagues, paired with live scores and elapsed time for context.


Claude-Session: https://claude.ai/code/session_0143YHKxcXpmmfYLWnbx6UdL