### PR TITLE
Fix !footyodds associating odds with the wrong team

### DIFF
--- a/broiestbot/commands/footy/predicts.py
+++ b/broiestbot/commands/footy/predicts.py
@@ -130,6 +130,47 @@ def fetch_today_fixture_odds_by_league(league_id: int, room: str, tz_name: str) 
         LOGGER.error(f"Unexpected error when fetching today's footy fixtures: {e}")
 
 
+def map_odds_by_fixture_id(fixtures_odds: List[dict]) -> dict:
+    """
+    Build a lookup of Match Winner odds keyed by fixture ID.
+
+    The fixtures and odds endpoints are separate API calls whose responses are not
+    guaranteed to be ordered identically, so odds must be matched to a fixture by ID
+    rather than by list position.
+
+    :param List[dict] fixtures_odds: Raw JSON response of today's fixtures' odds.
+
+    :returns: dict
+    """
+    odds_by_fixture_id = {}
+    for odds_entry in fixtures_odds:
+        fixture_id = odds_entry.get("fixture", {}).get("id")
+        bookmakers = odds_entry.get("bookmakers")
+        if fixture_id is None or not bookmakers:
+            continue
+        bets = bookmakers[0].get("bets")
+        if not bets:
+            continue
+        odds_by_fixture_id[fixture_id] = bets[0].get("values", [])
+    return odds_by_fixture_id
+
+
+def get_outcome_odds(values: List[dict], outcome: str) -> str:
+    """
+    Look up the odds for a single match outcome by its name.
+
+    API-Football does not guarantee the ordering of the `values` array, so outcomes
+    must be matched on the `value` field ("Home"/"Draw"/"Away") rather than by index;
+    otherwise home and away odds can be silently swapped.
+
+    :param List[dict] values: List of outcome/odd pairs for a fixture.
+    :param str outcome: Name of the outcome to look up ("Home", "Draw", or "Away").
+
+    :returns: str
+    """
+    return next((value["odd"] for value in values if value.get("value") == outcome), "N/A")
+
+
 def parse_fixture_odds(
     league_name: str, fixtures: dict, fixtures_odds: dict, room: str, username: str
 ) -> Optional[str]:
@@ -145,15 +186,17 @@ def parse_fixture_odds(
     :returns: str
     """
     try:
+        odds_by_fixture_id = map_odds_by_fixture_id(fixtures_odds)
         fixtures_odds_response = f"<b>{league_name}</b>\n"
         for i, fixture in enumerate(fixtures):
-            if fixtures_odds and i < 7:
+            values = odds_by_fixture_id.get(fixture["fixture"]["id"])
+            if values and i < 7:
                 fixture_start_time = datetime.strptime(fixture["fixture"]["date"], "%Y-%m-%dT%H:%M:%S%z").time()
                 home_team = abbreviate_team_name(fixture["teams"]["home"]["name"])
                 away_team = abbreviate_team_name(fixture["teams"]["away"]["name"])
-                home_odds = fixtures_odds[i]["bookmakers"][0]["bets"][0]["values"][0]["odd"]
-                draw_odds = fixtures_odds[i]["bookmakers"][0]["bets"][0]["values"][1]["odd"]
-                away_odds = fixtures_odds[i]["bookmakers"][0]["bets"][0]["values"][2]["odd"]
+                home_odds = get_outcome_odds(values, "Home")
+                draw_odds = get_outcome_odds(values, "Draw")
+                away_odds = get_outcome_odds(values, "Away")
                 fixture_odds_summary = f"<b>{away_team} @ {home_team}</b> | <i>{fixture_start_time}</i>\n \
                     {home_team.upper()}: {home_odds}\n \
                     DRAW: {draw_odds}\n \

--- a/broiestbot/commands/footy/tests/conftest.py
+++ b/broiestbot/commands/footy/tests/conftest.py
@@ -54,6 +54,76 @@ def live_odds_response_fixture(live_fixture) -> List[dict]:
 
 
 @pytest.fixture
+def today_fixture() -> dict:
+    """Single upcoming World Cup fixture as returned by /v3/fixtures?date=..."""
+    return {
+        "fixture": {
+            "id": 1489392,
+            "date": "2026-06-25T19:00:00+00:00",
+            "timezone": "UTC",
+            "status": {"long": "Not Started", "short": "NS", "elapsed": None},
+            "venue": {"name": "Levi's Stadium", "city": "Santa Clara"},
+        },
+        "league": {"id": 1, "name": "World Cup", "country": "World", "season": 2026},
+        "teams": {
+            "home": {"id": 10, "name": "United States", "winner": None},
+            "away": {"id": 24, "name": "Portugal", "winner": None},
+        },
+        "goals": {"home": None, "away": None},
+    }
+
+
+def _match_winner_odds_entry(fixture_id: int, values: List[dict]) -> dict:
+    """Build a single /v3/odds response entry for the 'Match Winner' bet (id=1)."""
+    return {
+        "fixture": {"id": fixture_id},
+        "bookmakers": [
+            {
+                "id": 8,
+                "name": "Bet365",
+                "bets": [{"id": 1, "name": "Match Winner", "values": values}],
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def today_odds_response(today_fixture) -> List[dict]:
+    """
+    Response from /v3/odds with the 'Match Winner' values in canonical Home/Draw/Away order.
+    """
+    return [
+        _match_winner_odds_entry(
+            today_fixture["fixture"]["id"],
+            [
+                {"value": "Home", "odd": "3.20"},
+                {"value": "Draw", "odd": "3.10"},
+                {"value": "Away", "odd": "2.25"},
+            ],
+        )
+    ]
+
+
+@pytest.fixture
+def today_odds_response_reversed(today_fixture) -> List[dict]:
+    """
+    Same odds as `today_odds_response`, but with the values returned in reverse
+    (Away/Draw/Home) order — the API does not guarantee ordering. Home odds must
+    still resolve to 3.20 and away to 2.25.
+    """
+    return [
+        _match_winner_odds_entry(
+            today_fixture["fixture"]["id"],
+            [
+                {"value": "Away", "odd": "2.25"},
+                {"value": "Draw", "odd": "3.10"},
+                {"value": "Home", "odd": "3.20"},
+            ],
+        )
+    ]
+
+
+@pytest.fixture
 def live_odds_no_fulltime_result(live_fixture) -> List[dict]:
     """Response that contains odds but no 'Fulltime Result' bet — should yield no parsed output."""
     return [

--- a/broiestbot/commands/footy/tests/test_predicts.py
+++ b/broiestbot/commands/footy/tests/test_predicts.py
@@ -1,0 +1,128 @@
+"""Tests for today's footy odds parsing logic (the !footyodds command)."""
+
+from broiestbot.commands.footy.predicts import (
+    get_outcome_odds,
+    map_odds_by_fixture_id,
+    parse_fixture_odds,
+)
+
+# ---------------------------------------------------------------------------
+# get_outcome_odds — the reverse-order bug
+# ---------------------------------------------------------------------------
+
+
+def test_get_outcome_odds_matches_by_value_name():
+    """Odds are looked up by their 'value' name, not by list position."""
+    values = [
+        {"value": "Home", "odd": "3.20"},
+        {"value": "Draw", "odd": "3.10"},
+        {"value": "Away", "odd": "2.25"},
+    ]
+    assert get_outcome_odds(values, "Home") == "3.20"
+    assert get_outcome_odds(values, "Draw") == "3.10"
+    assert get_outcome_odds(values, "Away") == "2.25"
+
+
+def test_get_outcome_odds_is_order_independent():
+    """
+    When the API returns outcomes in reverse (Away/Draw/Home) order, Home and Away
+    odds must still resolve to the correct value rather than being swapped.
+    """
+    reversed_values = [
+        {"value": "Away", "odd": "2.25"},
+        {"value": "Draw", "odd": "3.10"},
+        {"value": "Home", "odd": "3.20"},
+    ]
+    assert get_outcome_odds(reversed_values, "Home") == "3.20"
+    assert get_outcome_odds(reversed_values, "Away") == "2.25"
+
+
+def test_get_outcome_odds_returns_na_when_missing():
+    """A missing outcome falls back to 'N/A' rather than raising."""
+    assert get_outcome_odds([{"value": "Home", "odd": "3.20"}], "Away") == "N/A"
+    assert get_outcome_odds([], "Home") == "N/A"
+
+
+# ---------------------------------------------------------------------------
+# map_odds_by_fixture_id — match odds to fixtures by ID
+# ---------------------------------------------------------------------------
+
+
+def test_map_odds_by_fixture_id_keys_on_fixture_id(today_odds_response):
+    """Odds are keyed by fixture ID so they can be matched regardless of response order."""
+    result = map_odds_by_fixture_id(today_odds_response)
+    assert set(result.keys()) == {1489392}
+    assert result[1489392][0]["value"] == "Home"
+
+
+def test_map_odds_by_fixture_id_skips_entries_without_bookmakers():
+    """Entries lacking bookmakers/bets are skipped instead of raising."""
+    malformed = [
+        {"fixture": {"id": 1}, "bookmakers": []},
+        {"fixture": {"id": 2}, "bookmakers": [{"id": 8, "bets": []}]},
+        {"bookmakers": [{"id": 8, "bets": [{"values": [{"value": "Home", "odd": "1.5"}]}]}]},
+    ]
+    assert map_odds_by_fixture_id(malformed) == {}
+
+
+# ---------------------------------------------------------------------------
+# parse_fixture_odds — integration-style
+# ---------------------------------------------------------------------------
+
+
+def test_parse_fixture_odds_associates_odds_with_correct_team(today_fixture, today_odds_response):
+    """Home/draw/away odds are rendered against the correct team."""
+    result = parse_fixture_odds("WORLD CUP", [today_fixture], today_odds_response, "room", "user")
+
+    assert result is not None
+    # United States is home (3.20), Portugal is away (2.25).
+    assert "UNITED STATES: 3.20" in result
+    assert "DRAW: 3.10" in result
+    assert "PORTUGAL: 2.25" in result
+
+
+def test_parse_fixture_odds_correct_when_outcomes_reversed(today_fixture, today_odds_response_reversed):
+    """
+    Regression test: when the odds API returns outcomes in Away/Draw/Home order,
+    the home team must still be paired with the home odds (not the away odds).
+    """
+    result = parse_fixture_odds("WORLD CUP", [today_fixture], today_odds_response_reversed, "room", "user")
+
+    assert result is not None
+    assert "UNITED STATES: 3.20" in result
+    assert "PORTUGAL: 2.25" in result
+
+
+def test_parse_fixture_odds_matches_by_fixture_id_not_position(today_fixture, today_odds_response):
+    """
+    Odds for an unrelated fixture appearing earlier in the odds response must not be
+    attributed to this fixture; matching is by ID, not list position.
+    """
+    unrelated = {
+        "fixture": {"id": 999999},
+        "bookmakers": [
+            {
+                "id": 8,
+                "name": "Bet365",
+                "bets": [
+                    {
+                        "id": 1,
+                        "name": "Match Winner",
+                        "values": [
+                            {"value": "Home", "odd": "9.99"},
+                            {"value": "Draw", "odd": "9.99"},
+                            {"value": "Away", "odd": "9.99"},
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    odds_response = [unrelated] + today_odds_response
+
+    result = parse_fixture_odds("WORLD CUP", [today_fixture], odds_response, "room", "user")
+
+    assert result is not None
+    assert "9.99" not in result
+    assert "UNITED STATES: 3.20" in result
+    assert "PORTUGAL: 2.25" in result


### PR DESCRIPTION
parse_fixture_odds read Match Winner odds positionally
(values[0/1/2] -> Home/Draw/Away) and matched the odds response
to fixtures by list index. API-Football guarantees neither the
ordering of the values array nor that the fixtures and odds
endpoints return fixtures in the same order, so home and away odds
were silently swapped roughly half the time.

Look up each outcome by its "value" name ("Home"/"Draw"/"Away") via
get_outcome_odds, and match odds to fixtures by fixture id via
map_odds_by_fixture_id. Add tests covering reversed value ordering
and mismatched odds/fixture ordering.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XTdUQJLqpzSJQ5qNZUTvW9