### PR TITLE
Add `!f1` command summarizing the state of an F1 grand prix

### DIFF
--- a/broiestbot/bot.py
+++ b/broiestbot/bot.py
@@ -18,6 +18,7 @@ from broiestbot.commands import (  # get_crypto_chart,
     covid_cases_usa,
     create_wiki_preview,
     epl_golden_boot,
+    f1_grand_prix,
     fetch_aafk_fixture_data,
     fetch_fox_fixtures,
     fetch_latest_image_from_gcs_bucket,
@@ -36,7 +37,6 @@ from broiestbot.commands import (  # get_crypto_chart,
     generate_llm_response,
     generate_twitter_preview,
     generate_youtube_video_preview,
-    search_youtube_video,
     get_all_live_twitch_streams,
     get_crypto_price,
     get_current_show,
@@ -270,6 +270,8 @@ class Bot(chatango.Client):
             return today_sumo_matches()
         elif cmd_type == "sumo":
             return upcoming_sumo_matches()
+        elif cmd_type == "f1":
+            return f1_grand_prix()
         elif cmd_type == "nbastandings":
             return nba_standings()
         elif cmd_type == "nbagames":

--- a/broiestbot/commands/__init__.py
+++ b/broiestbot/commands/__init__.py
@@ -9,6 +9,7 @@ from .definitions import (
     wiki_summary,
 )
 from .embeds import create_instagram_preview, generate_twitter_preview
+from .f1 import f1_grand_prix
 from .footy import (
     all_leagues_golden_boot,
     epl_golden_boot,

--- a/broiestbot/commands/f1/__init__.py
+++ b/broiestbot/commands/f1/__init__.py
@@ -1,0 +1,1 @@
+from .grandprix import f1_grand_prix

--- a/broiestbot/commands/f1/grandprix.py
+++ b/broiestbot/commands/f1/grandprix.py
@@ -1,0 +1,289 @@
+"""Summarize the state of F1: a live grand prix, the next grand prix, or the offseason."""
+
+from datetime import datetime, timedelta, timezone
+from typing import List, Optional, Tuple
+
+from emoji import emojize
+from logger import LOGGER
+
+from config import F1_ODDS_DRIVER_LIMIT, F1_QUALIFYING_LOOKAHEAD_HOURS
+
+from .odds import fetch_race_winner_odds
+from .races import (
+    current_lap,
+    fetch_race_rankings,
+    fetch_season_races,
+    fetch_starting_grid,
+    find_live_race,
+    find_next_race,
+)
+from .util import (
+    country_flag,
+    driver_flag,
+    driver_flag_from_name,
+    format_countdown,
+    format_odds,
+    format_race_date,
+    parse_race_date,
+)
+
+API_ERROR_MESSAGE = emojize(":warning: idk the F1 API shit the bed, try again later.", language="en")
+
+
+def f1_grand_prix_at(now: datetime) -> str:
+    """
+    Summarize the state of F1 at a given moment: a live race, the next race, or the offseason.
+
+    :param datetime now: Current UTC time.
+
+    :returns: str
+    """
+    try:
+        races = fetch_season_races(now.year)
+        if races is None:
+            return API_ERROR_MESSAGE
+        live_race = find_live_race(races, now)
+        if live_race:
+            return live_race_message(live_race)
+        next_race = find_next_race(races, now)
+        if next_race is None:
+            return offseason_message(now.year, now, bool(races))
+        return upcoming_race_message(next_race, now)
+    except Exception as e:
+        LOGGER.exception(f"Unexpected error while building F1 grand prix message: {e}")
+        return API_ERROR_MESSAGE
+
+
+def f1_grand_prix() -> str:
+    """
+    Summarize the current state of F1, whether that's a live race, the next race, or the offseason.
+
+    :returns: str
+    """
+    return f1_grand_prix_at(datetime.now(timezone.utc))
+
+
+def live_race_message(race: dict) -> str:
+    """
+    Summarize a grand prix which is currently being run, including live driver positions.
+
+    :param dict race: Race object returned by the F1 API.
+
+    :returns: str
+    """
+    message = _race_header(race, ":racing_car:", "LIVE NOW")
+    message += _race_details(race)
+    lap = current_lap(race)
+    if lap:
+        message += emojize(f":stopwatch: <b>Lap {lap}</b>\n", language="en")
+    positions = _sort_by_position(fetch_race_rankings(race.get("id")) or [])
+    if positions:
+        message += "\n"
+        for entry in positions:
+            message += _ranking_line(entry)
+        return message
+    # Positions aren't published until a race is properly underway; odds fill the gap until then.
+    return message + _odds_section(race)
+
+
+def upcoming_race_message(race: dict, now: datetime) -> str:
+    """
+    Summarize the next grand prix, listing the starting grid if qualifying is done, else odds.
+
+    :param dict race: Race object returned by the F1 API.
+    :param datetime now: Current UTC time.
+
+    :returns: str
+    """
+    message = _race_header(race, ":racing_car:", "NEXT UP")
+    message += _race_details(race)
+    start_time = parse_race_date(race.get("date"))
+    if start_time:
+        message += emojize(
+            f":calendar: {format_race_date(start_time)} <i>({format_countdown(start_time - now)})</i>\n",
+            language="en",
+        )
+    if start_time and start_time - now <= timedelta(hours=F1_QUALIFYING_LOOKAHEAD_HOURS):
+        grid = _sort_by_position(fetch_starting_grid(race.get("id")) or [])
+        if grid:
+            message += emojize("\n:chequered_flag: <b>STARTING GRID</b>\n", language="en")
+            for entry in grid:
+                message += _grid_line(entry)
+            return message
+    return message + _odds_section(race)
+
+
+def offseason_message(season: int, now: datetime, season_had_races: bool = True) -> str:
+    """
+    Report that the F1 season has ended, along with the start of the next season (when known).
+
+    :param int season: Year of the season which has ended.
+    :param datetime now: Current UTC time.
+    :param bool season_had_races: Whether the season had any races on the schedule to begin with.
+
+    :returns: str
+    """
+    if season_had_races:
+        message = emojize(f":chequered_flag: <b>the {season} F1 season is over</b>, BROH.\n", language="en")
+    else:
+        message = emojize(f":chequered_flag: <b>no {season} F1 races on the schedule</b>, BROH.\n", language="en")
+    next_season_races = fetch_season_races(season + 1) or []
+    next_season_start = _first_race_of_season(next_season_races)
+    if next_season_start is None:
+        return message + emojize(
+            f":hourglass_not_done: the {season + 1} schedule hasn't been announced yet.",
+            language="en",
+        )
+    race, start_time = next_season_start
+    message += emojize(
+        f":racing_car: <b>{_grand_prix_name(race)}</b> kicks off the {season + 1} season "
+        f"on {format_race_date(start_time)} <i>({format_countdown(start_time - now)})</i>.",
+        language="en",
+    )
+    return message
+
+
+def _first_race_of_season(races: List[dict]) -> Optional[Tuple[dict, datetime]]:
+    """
+    Earliest scheduled race of a season, paired with its start time.
+
+    :param List[dict] races: All races in a season.
+
+    :returns: Optional[Tuple[dict, datetime]]
+    """
+    scheduled_races = [(race, parse_race_date(race.get("date"))) for race in races]
+    scheduled_races = [(race, start_time) for race, start_time in scheduled_races if start_time]
+    if scheduled_races:
+        return min(scheduled_races, key=lambda race: race[1])
+    return None
+
+
+def _race_header(race: dict, icon: str, label: str) -> str:
+    """
+    Construct the opening line of a grand prix summary.
+
+    :param dict race: Race object returned by the F1 API.
+    :param str icon: Emoji shortcode to lead the message with.
+    :param str label: Status of the grand prix, ie: `LIVE NOW`.
+
+    :returns: str
+    """
+    location = (race.get("competition") or {}).get("location") or {}
+    flag = country_flag(location.get("country"))
+    return emojize(
+        f"\n\n\n{icon} <b>{label}: {_grand_prix_name(race).upper()}</b> {flag}\n",
+        language="en",
+    )
+
+
+def _race_details(race: dict) -> str:
+    """
+    Construct circuit, lap count & weather details of a grand prix.
+
+    :param dict race: Race object returned by the F1 API.
+
+    :returns: str
+    """
+    details = ""
+    circuit_name = (race.get("circuit") or {}).get("name")
+    location = (race.get("competition") or {}).get("location") or {}
+    venue = ", ".join([detail for detail in (circuit_name, location.get("city")) if detail])
+    if venue:
+        details += f"<i>{venue}</i>\n"
+    total_laps = (race.get("laps") or {}).get("total")
+    distance = race.get("distance")
+    race_length = ", ".join(
+        [str(detail) for detail in (f"{total_laps} laps" if total_laps else None, distance) if detail]
+    )
+    if race_length:
+        details += f"{race_length}\n"
+    if race.get("weather"):
+        details += f"{race['weather']}\n"
+    return details
+
+
+def _odds_section(race: dict) -> str:
+    """
+    Construct a list of drivers by their odds of winning a grand prix.
+
+    :param dict race: Race object returned by the F1 API.
+
+    :returns: str
+    """
+    odds = fetch_race_winner_odds(race)
+    if not odds:
+        return emojize(":warning: <i>no odds available for this one.</i>", language="en")
+    section = emojize("\n:money_bag: <b>ODDS TO WIN</b>\n", language="en")
+    for driver_name, price in odds[:F1_ODDS_DRIVER_LIMIT]:
+        section += f"{driver_flag_from_name(driver_name)} {driver_name}: <b>{format_odds(price)}</b>\n"
+    return section
+
+
+def _ranking_line(entry: dict) -> str:
+    """
+    Construct a single driver's line in a live race's running order.
+
+    :param dict entry: Driver ranking returned by the F1 API.
+
+    :returns: str
+    """
+    driver = entry.get("driver") or {}
+    team = (entry.get("team") or {}).get("name")
+    gap = entry.get("gap") or entry.get("time") or ""
+    line = f"<b>{entry['position']}.</b> {driver_flag(driver)} {driver.get('name', 'Unknown')}"
+    if team:
+        line += f" <i>({team})</i>"
+    if gap:
+        line += f" {gap}"
+    return line + "\n"
+
+
+def _grid_line(entry: dict) -> str:
+    """
+    Construct a single driver's line in a starting grid.
+
+    :param dict entry: Starting grid position returned by the F1 API.
+
+    :returns: str
+    """
+    driver = entry.get("driver") or {}
+    team = (entry.get("team") or {}).get("name")
+    lap_time = entry.get("time") or ""
+    line = f"<b>P{entry['position']}</b> {driver_flag(driver)} {driver.get('name', 'Unknown')}"
+    if team:
+        line += f" <i>({team})</i>"
+    if lap_time:
+        line += f" {lap_time}"
+    return line + "\n"
+
+
+def _sort_by_position(entries: List[dict]) -> List[dict]:
+    """
+    Sort driver rankings or grid slots by position, dropping any which lack one.
+
+    :param List[dict] entries: Driver rankings or starting grid positions.
+
+    :returns: List[dict]
+    """
+    positioned_entries = []
+    for entry in entries:
+        try:
+            entry["position"] = int(entry["position"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        positioned_entries.append(entry)
+    return sorted(positioned_entries, key=lambda entry: entry["position"])
+
+
+def _grand_prix_name(race: dict) -> str:
+    """
+    Full name of a grand prix, ie: `Bahrain Grand Prix`.
+
+    :param dict race: Race object returned by the F1 API.
+
+    :returns: str
+    """
+    competition_name = (race.get("competition") or {}).get("name") or "Formula 1"
+    if "grand prix" in competition_name.lower():
+        return competition_name
+    return f"{competition_name} Grand Prix"

--- a/broiestbot/commands/f1/odds.py
+++ b/broiestbot/commands/f1/odds.py
@@ -1,0 +1,191 @@
+"""Fetch bookmaker odds of drivers winning a grand prix."""
+
+from typing import List, Optional, Tuple
+
+import requests
+from logger import LOGGER
+from requests.exceptions import HTTPError
+
+from config import (
+    F1_ODDS_HTTP_HEADERS,
+    F1_ODDS_SPECIAL_MARKETS_ENDPOINT,
+    F1_ODDS_SPORTS_ENDPOINT,
+    HTTP_REQUEST_TIMEOUT,
+)
+
+from .util import normalize_name, parse_race_date
+
+# Cached sport ID of F1, which is resolved by name to avoid hardcoding a bookmaker's internal ID.
+_F1_SPORT_ID: Optional[int] = None
+
+
+def fetch_f1_sport_id() -> Optional[int]:
+    """
+    Look up (and cache) the bookmaker's ID for Formula 1.
+
+    :returns: Optional[int]
+    """
+    global _F1_SPORT_ID
+    if _F1_SPORT_ID is not None:
+        return _F1_SPORT_ID
+    sports = _fetch_odds_data(F1_ODDS_SPORTS_ENDPOINT, {}, "sports")
+    if not sports:
+        return None
+    for sport in sports:
+        if "formula" in (sport.get("name") or "").lower() and sport.get("id"):
+            _F1_SPORT_ID = int(sport["id"])
+            return _F1_SPORT_ID
+    LOGGER.warning("No Formula 1 sport found in odds API's list of sports.")
+    return None
+
+
+def fetch_race_winner_odds(race: dict) -> Optional[List[Tuple[str, float]]]:
+    """
+    Fetch each driver's odds of winning a given grand prix, sorted by favorite.
+
+    :param dict race: Race object returned by the F1 API.
+
+    :returns: Optional[List[Tuple[str, float]]]
+    """
+    try:
+        sport_id = fetch_f1_sport_id()
+        if sport_id is None:
+            return None
+        for event_type in ("prematch", "live"):
+            specials = _fetch_odds_data(
+                F1_ODDS_SPECIAL_MARKETS_ENDPOINT,
+                {"sport_id": sport_id, "event_type": event_type, "is_have_odds": "true"},
+                "specials",
+            )
+            if not specials:
+                continue
+            market = _match_race_winner_market(specials, race)
+            if market:
+                odds = _parse_odds_from_market(market)
+                if odds:
+                    return odds
+        LOGGER.warning(f"No race-winner odds found for F1 race `{race.get('id')}`.")
+    except Exception as e:
+        LOGGER.exception(f"Unexpected error while fetching F1 race winner odds: {e}")
+    return None
+
+
+def _fetch_odds_data(endpoint: str, params: dict, response_key: str) -> Optional[List[dict]]:
+    """
+    Fetch & unwrap a response from the odds API.
+
+    :param str endpoint: Odds API endpoint to be fetched.
+    :param dict params: Query parameters to be passed to the endpoint.
+    :param str response_key: Key which the endpoint nests its results under.
+
+    :returns: Optional[List[dict]]
+    """
+    try:
+        resp = requests.get(
+            endpoint,
+            headers=F1_ODDS_HTTP_HEADERS,
+            params=params,
+            timeout=HTTP_REQUEST_TIMEOUT,
+        )
+        if resp.status_code != 200:
+            LOGGER.warning(f"Non-200 response from odds API `{endpoint}`: {resp.status_code} {resp.text[:300]}")
+            return None
+        data = resp.json()
+        if isinstance(data, dict):
+            data = data.get(response_key)
+        if isinstance(data, list):
+            return data
+        LOGGER.warning(f"Unexpected response shape from odds API `{endpoint}`: {str(data)[:300]}")
+    except HTTPError as e:
+        LOGGER.exception(f"HTTPError while fetching odds from `{endpoint}`: {getattr(e.response, 'content', e)}")
+    except ValueError as e:
+        LOGGER.exception(f"Malformed JSON returned by odds API `{endpoint}`: {e}")
+    except Exception as e:
+        LOGGER.exception(f"Unexpected error while fetching odds from `{endpoint}`: {e}")
+    return None
+
+
+def _match_race_winner_market(specials: List[dict], race: dict) -> Optional[dict]:
+    """
+    Find the race-winner market which belongs to a given grand prix.
+
+    Markets are matched on the grand prix' name/location, falling back to whichever
+    winner market starts closest to the race itself.
+
+    :param List[dict] specials: Special (outright) markets offered for F1.
+    :param dict race: Race object returned by the F1 API.
+
+    :returns: Optional[dict]
+    """
+    race_start = parse_race_date(race.get("date"))
+    candidates = []
+    for special in specials:
+        if not _parse_odds_from_market(special):
+            continue
+        description = normalize_name(
+            " ".join(
+                [
+                    str(special.get("category") or ""),
+                    str(special.get("name") or ""),
+                    str(special.get("league_name") or ""),
+                ]
+            )
+        )
+        if "winner" not in description:
+            continue
+        market_start = parse_race_date(special.get("starts") or special.get("cutoff"))
+        matches_race = any(term and term in description for term in _race_search_terms(race))
+        if race_start and market_start:
+            proximity = abs((market_start - race_start).total_seconds())
+        else:
+            proximity = float("inf")
+        candidates.append((not matches_race, proximity, special))
+    if candidates:
+        return min(candidates, key=lambda candidate: (candidate[0], candidate[1]))[2]
+    return None
+
+
+def _race_search_terms(race: dict) -> List[str]:
+    """
+    Terms which identify a grand prix in a bookmaker's market name.
+
+    :param dict race: Race object returned by the F1 API.
+
+    :returns: List[str]
+    """
+    competition = race.get("competition") or {}
+    location = competition.get("location") or {}
+    circuit = race.get("circuit") or {}
+    return [
+        normalize_name(competition.get("name")),
+        normalize_name(location.get("city")),
+        normalize_name(location.get("country")),
+        normalize_name(circuit.get("name")),
+    ]
+
+
+def _parse_odds_from_market(market: dict) -> List[Tuple[str, float]]:
+    """
+    Parse driver names & prices out of a bookmaker's market, sorted by favorite.
+
+    :param dict market: Special (outright) market offered for F1.
+
+    :returns: List[Tuple[str, float]]
+    """
+    lines = market.get("lines") or market.get("participants") or []
+    if isinstance(lines, dict):
+        lines = list(lines.values())
+    odds = []
+    for line in lines:
+        if not isinstance(line, dict):
+            continue
+        name = line.get("name") or line.get("participant") or line.get("driver")
+        price = line.get("price", line.get("odds", line.get("moneyline")))
+        try:
+            price = float(price)
+        except (TypeError, ValueError):
+            continue
+        if name and price:
+            odds.append((str(name), price))
+    # Ascending price is favorite-first for both decimal (1.72 < 26.0) and American (-140 < +2500) prices.
+    return sorted(odds, key=lambda driver: driver[1])

--- a/broiestbot/commands/f1/races.py
+++ b/broiestbot/commands/f1/races.py
@@ -1,0 +1,196 @@
+"""Fetch F1 races, results & starting grids from the Formula 1 API."""
+
+from datetime import datetime, timedelta
+from typing import List, Optional
+
+import requests
+from logger import LOGGER
+from requests.exceptions import HTTPError
+
+from config import (
+    F1_HTTP_HEADERS,
+    F1_RACE_LIVE_WINDOW_HOURS,
+    F1_RACE_RANKINGS_ENDPOINT,
+    F1_RACES_ENDPOINT,
+    F1_STARTING_GRID_ENDPOINT,
+    HTTP_REQUEST_TIMEOUT,
+)
+
+from .util import parse_race_date
+
+# Race statuses which mean a grand prix will never be run again.
+RACE_FINISHED_STATUSES = ("completed", "finished")
+RACE_ABANDONED_STATUSES = ("cancelled", "canceled", "postponed")
+# Statuses which explicitly flag a grand prix as underway.
+RACE_LIVE_STATUSES = ("live", "in progress", "started", "running")
+
+
+def fetch_season_races(season: int) -> Optional[List[dict]]:
+    """
+    Fetch every grand prix (race sessions only) scheduled for a given season.
+
+    :param int season: Year of an F1 season, ie: `2026`.
+
+    :returns: Optional[List[dict]]
+    """
+    return _fetch_f1_data(F1_RACES_ENDPOINT, {"season": season, "type": "Race", "timezone": "UTC"})
+
+
+def fetch_race_rankings(race_id: int) -> Optional[List[dict]]:
+    """
+    Fetch driver standings for a single race (live positions while a race is underway).
+
+    :param int race_id: ID of a single grand prix.
+
+    :returns: Optional[List[dict]]
+    """
+    return _fetch_f1_data(F1_RACE_RANKINGS_ENDPOINT, {"race": race_id})
+
+
+def fetch_starting_grid(race_id: int) -> Optional[List[dict]]:
+    """
+    Fetch the starting grid of a single race, which only exists once qualifying is complete.
+
+    :param int race_id: ID of a single grand prix.
+
+    :returns: Optional[List[dict]]
+    """
+    return _fetch_f1_data(F1_STARTING_GRID_ENDPOINT, {"race": race_id})
+
+
+def _fetch_f1_data(endpoint: str, params: dict) -> Optional[List[dict]]:
+    """
+    Fetch & unwrap a response from the Formula 1 API.
+
+    :param str endpoint: Formula 1 API endpoint to be fetched.
+    :param dict params: Query parameters to be passed to the endpoint.
+
+    :returns: Optional[List[dict]]
+    """
+    try:
+        resp = requests.get(
+            endpoint,
+            headers=F1_HTTP_HEADERS,
+            params=params,
+            timeout=HTTP_REQUEST_TIMEOUT,
+        )
+        if resp.status_code == 200:
+            return resp.json().get("response")
+        LOGGER.warning(f"Non-200 response from F1 API `{endpoint}` {params}: {resp.status_code} {resp.text[:300]}")
+    except HTTPError as e:
+        LOGGER.exception(f"HTTPError while fetching F1 data from `{endpoint}`: {getattr(e.response, 'content', e)}")
+    except ValueError as e:
+        LOGGER.exception(f"Malformed JSON returned by F1 API `{endpoint}`: {e}")
+    except Exception as e:
+        LOGGER.exception(f"Unexpected error while fetching F1 data from `{endpoint}`: {e}")
+    return None
+
+
+def race_status(race: dict) -> str:
+    """
+    Normalized status of a race, ie: `completed`.
+
+    :param dict race: Race object returned by the F1 API.
+
+    :returns: str
+    """
+    return (race.get("status") or "").strip().lower()
+
+
+def is_race_finished(race: dict) -> bool:
+    """
+    Whether a race has been run to completion.
+
+    :param dict race: Race object returned by the F1 API.
+
+    :returns: bool
+    """
+    return race_status(race) in RACE_FINISHED_STATUSES
+
+
+def is_race_abandoned(race: dict) -> bool:
+    """
+    Whether a race has been called off, and as such should never be reported on.
+
+    :param dict race: Race object returned by the F1 API.
+
+    :returns: bool
+    """
+    return race_status(race) in RACE_ABANDONED_STATUSES
+
+
+def is_race_live(race: dict, now: datetime) -> bool:
+    """
+    Whether a race is currently being run.
+
+    A race counts as live when the API says so outright, or when it has started
+    within the last few hours without being flagged as finished (red flags, rain
+    delays and safety car parades all stretch a race well beyond its scheduled runtime).
+
+    :param dict race: Race object returned by the F1 API.
+    :param datetime now: Current UTC time.
+
+    :returns: bool
+    """
+    if is_race_finished(race) or is_race_abandoned(race):
+        return False
+    if race_status(race) in RACE_LIVE_STATUSES:
+        return True
+    start_time = parse_race_date(race.get("date"))
+    if start_time is None:
+        return False
+    return start_time <= now <= start_time + timedelta(hours=F1_RACE_LIVE_WINDOW_HOURS)
+
+
+def find_live_race(races: List[dict], now: datetime) -> Optional[dict]:
+    """
+    Find the grand prix currently underway, if any.
+
+    :param List[dict] races: All races in a season.
+    :param datetime now: Current UTC time.
+
+    :returns: Optional[dict]
+    """
+    live_races = [race for race in races if is_race_live(race, now)]
+    if live_races:
+        return sorted(live_races, key=lambda race: parse_race_date(race.get("date")) or now)[-1]
+    return None
+
+
+def find_next_race(races: List[dict], now: datetime) -> Optional[dict]:
+    """
+    Find the next grand prix yet to be run.
+
+    :param List[dict] races: All races in a season.
+    :param datetime now: Current UTC time.
+
+    :returns: Optional[dict]
+    """
+    upcoming_races = []
+    for race in races:
+        if is_race_finished(race) or is_race_abandoned(race):
+            continue
+        start_time = parse_race_date(race.get("date"))
+        if start_time and start_time > now:
+            upcoming_races.append((start_time, race))
+    if upcoming_races:
+        return min(upcoming_races, key=lambda race: race[0])[1]
+    return None
+
+
+def current_lap(race: dict) -> Optional[str]:
+    """
+    Lap a live race is currently on, ie: `32/57`.
+
+    :param dict race: Race object returned by the F1 API.
+
+    :returns: Optional[str]
+    """
+    laps = race.get("laps") or {}
+    lap = laps.get("current")
+    total_laps = laps.get("total")
+    if lap and total_laps:
+        return f"{lap}/{total_laps}"
+    if lap:
+        return str(lap)
+    return None

--- a/broiestbot/commands/f1/tests/conftest.py
+++ b/broiestbot/commands/f1/tests/conftest.py
@@ -1,0 +1,198 @@
+"""Shared fixtures for Formula 1 command tests."""
+
+from typing import List
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Races (api-formula-1 /races?season=<season>&type=Race)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def race_upcoming() -> dict:
+    """Scheduled grand prix which hasn't been run yet."""
+    return {
+        "id": 1141,
+        "competition": {
+            "id": 21,
+            "name": "Bahrain",
+            "location": {"country": "Bahrain", "city": "Sakhir"},
+        },
+        "circuit": {"id": 21, "name": "Bahrain International Circuit"},
+        "season": 2026,
+        "type": "Race",
+        "laps": {"current": None, "total": 57},
+        "fastest_lap": {"driver": {"id": None}, "time": None},
+        "distance": "308.238 km",
+        "timezone": "UTC",
+        "date": "2026-03-08T15:00:00+00:00",
+        "weather": None,
+        "status": "Scheduled",
+    }
+
+
+@pytest.fixture
+def race_live(race_upcoming) -> dict:
+    """Grand prix currently being run, 32 laps in."""
+    return {
+        **race_upcoming,
+        "id": 1142,
+        "laps": {"current": 32, "total": 57},
+        "date": "2026-03-08T15:00:00+00:00",
+        "weather": "Sunny, 28°C",
+        "status": "Scheduled",
+    }
+
+
+@pytest.fixture
+def race_completed(race_upcoming) -> dict:
+    """Grand prix which has already been run."""
+    return {
+        **race_upcoming,
+        "id": 1140,
+        "competition": {
+            "id": 20,
+            "name": "Australia",
+            "location": {"country": "Australia", "city": "Melbourne"},
+        },
+        "laps": {"current": 58, "total": 58},
+        "date": "2026-03-01T05:00:00+00:00",
+        "status": "Completed",
+    }
+
+
+@pytest.fixture
+def race_cancelled(race_upcoming) -> dict:
+    """Grand prix which was called off."""
+    return {**race_upcoming, "id": 1139, "date": "2026-03-22T15:00:00+00:00", "status": "Cancelled"}
+
+
+# ---------------------------------------------------------------------------
+# Driver rankings (api-formula-1 /rankings/races?race=<race>)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def race_rankings() -> List[dict]:
+    """Running order of a live race, deliberately out of order."""
+    return [
+        {
+            "position": 3,
+            "driver": {"id": 25, "name": "Lewis Hamilton", "abbr": "HAM", "number": 44},
+            "team": {"id": 3, "name": "Ferrari"},
+            "time": None,
+            "gap": "+8.921",
+            "laps": 32,
+            "pits": 1,
+        },
+        {
+            "position": 1,
+            "driver": {"id": 20, "name": "Max Verstappen", "abbr": "VER", "number": 1},
+            "team": {"id": 1, "name": "Red Bull Racing"},
+            "time": "1:02:11.404",
+            "gap": None,
+            "laps": 32,
+            "pits": 1,
+        },
+        {
+            "position": 2,
+            "driver": {"id": 22, "name": "Charles Leclerc", "abbr": "LEC", "number": 16},
+            "team": {"id": 3, "name": "Ferrari"},
+            "time": None,
+            "gap": "+2.104",
+            "laps": 32,
+            "pits": 1,
+        },
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Starting grid (api-formula-1 /rankings/startinggrid?race=<race>)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def starting_grid() -> List[dict]:
+    """Starting grid of a race whose qualifying is complete, deliberately out of order."""
+    return [
+        {
+            "position": 2,
+            "driver": {"id": 25, "name": "Nico Hulkenberg", "abbr": "HUL", "number": 27},
+            "team": {"id": 6, "name": "Audi"},
+            "time": "1:29.512",
+        },
+        {
+            "position": 1,
+            "driver": {"id": 20, "name": "Max Verstappen", "abbr": "VER", "number": 1},
+            "team": {"id": 1, "name": "Red Bull Racing"},
+            "time": "1:29.179",
+        },
+        {
+            "position": 3,
+            "driver": {"id": 30, "name": "Yuki Tsunoda", "abbr": "TSU", "number": 22},
+            "team": {"id": 2, "name": "Racing Bulls"},
+            "time": "1:29.740",
+        },
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Bookmaker odds (pinnacle-odds /kit/v1/sports & /kit/v1/special-markets)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def odds_sports() -> List[dict]:
+    """Sports offered by the odds API."""
+    return [
+        {"id": 1, "name": "Soccer"},
+        {"id": 3, "name": "Basketball"},
+        {"id": 12, "name": "Formula 1"},
+    ]
+
+
+@pytest.fixture
+def odds_race_winner_market() -> dict:
+    """Race-winner market for the Bahrain Grand Prix."""
+    return {
+        "id": 1587215144,
+        "sport_id": 12,
+        "league_id": 3435,
+        "league_name": "Formula 1",
+        "category": "Race Winner",
+        "name": "Bahrain Grand Prix - Winner",
+        "starts": "2026-03-08T15:00:00Z",
+        "lines": {
+            "0": {"line_id": 1, "name": "Charles Leclerc", "price": 4.5},
+            "1": {"line_id": 2, "name": "Max Verstappen", "price": 1.72},
+            "2": {"line_id": 3, "name": "Lando Norris", "price": 3.25},
+            "3": {"line_id": 4, "name": "Franco Colapinto", "price": None},
+        },
+    }
+
+
+@pytest.fixture
+def odds_specials(odds_race_winner_market) -> List[dict]:
+    """Special (outright) markets offered for F1, including irrelevant ones."""
+    return [
+        {
+            "id": 1587215100,
+            "sport_id": 12,
+            "league_name": "Formula 1",
+            "category": "Drivers Championship",
+            "name": "2026 Drivers Championship - Winner",
+            "starts": "2026-03-08T15:00:00Z",
+            "lines": {"0": {"line_id": 9, "name": "Max Verstappen", "price": 2.1}},
+        },
+        {
+            "id": 1587215101,
+            "sport_id": 12,
+            "league_name": "Formula 1",
+            "category": "Fastest Lap",
+            "name": "Bahrain Grand Prix - Fastest Lap",
+            "starts": "2026-03-08T15:00:00Z",
+            "lines": {"0": {"line_id": 10, "name": "Lando Norris", "price": 3.0}},
+        },
+        odds_race_winner_market,
+    ]

--- a/broiestbot/commands/f1/tests/test_grandprix.py
+++ b/broiestbot/commands/f1/tests/test_grandprix.py
@@ -1,0 +1,182 @@
+"""Tests for the `!f1` grand prix summary."""
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from broiestbot.commands.f1.grandprix import API_ERROR_MESSAGE, f1_grand_prix_at
+
+RACE_WINNER_ODDS = [("Max Verstappen", 1.72), ("Lando Norris", 3.25), ("Charles Leclerc", 4.5)]
+
+# ---------------------------------------------------------------------------
+# Live grand prix
+# ---------------------------------------------------------------------------
+
+
+def test_live_race_lists_drivers_by_position(race_live, race_rankings):
+    """A live race reports its current lap & running order."""
+    with (
+        patch("broiestbot.commands.f1.grandprix.fetch_season_races", return_value=[race_live]),
+        patch("broiestbot.commands.f1.grandprix.fetch_race_rankings", return_value=race_rankings),
+        patch("broiestbot.commands.f1.grandprix.fetch_race_winner_odds") as mock_odds,
+    ):
+        result = f1_grand_prix_at(datetime(2026, 3, 8, 16, tzinfo=timezone.utc))
+
+    assert "LIVE NOW: BAHRAIN GRAND PRIX" in result
+    assert "🇧🇭" in result
+    assert "Bahrain International Circuit, Sakhir" in result
+    assert "Lap 32/57" in result
+    assert "<b>1.</b> 🇳🇱 Max Verstappen <i>(Red Bull Racing)</i> 1:02:11.404" in result
+    assert "<b>2.</b> 🇲🇨 Charles Leclerc <i>(Ferrari)</i> +2.104" in result
+    assert "<b>3.</b> 🇬🇧 Lewis Hamilton <i>(Ferrari)</i> +8.921" in result
+    # Positions are listed in running order, not the order the API returned them.
+    assert result.index("Max Verstappen") < result.index("Charles Leclerc") < result.index("Lewis Hamilton")
+    mock_odds.assert_not_called()
+
+
+def test_live_race_falls_back_to_odds_without_positions(race_live):
+    """A live race with no published positions lists drivers by odds instead."""
+    with (
+        patch("broiestbot.commands.f1.grandprix.fetch_season_races", return_value=[race_live]),
+        patch("broiestbot.commands.f1.grandprix.fetch_race_rankings", return_value=[]),
+        patch("broiestbot.commands.f1.grandprix.fetch_race_winner_odds", return_value=RACE_WINNER_ODDS),
+    ):
+        result = f1_grand_prix_at(datetime(2026, 3, 8, 16, tzinfo=timezone.utc))
+
+    assert "LIVE NOW: BAHRAIN GRAND PRIX" in result
+    assert "Lap 32/57" in result
+    assert "ODDS TO WIN" in result
+    assert "🇳🇱 Max Verstappen: <b>1.72</b>" in result
+
+
+# ---------------------------------------------------------------------------
+# Upcoming grand prix
+# ---------------------------------------------------------------------------
+
+
+def test_upcoming_race_lists_drivers_by_odds(race_completed, race_upcoming):
+    """A race which is still days out is listed with odds to win, favorite first."""
+    with (
+        patch("broiestbot.commands.f1.grandprix.fetch_season_races", return_value=[race_completed, race_upcoming]),
+        patch("broiestbot.commands.f1.grandprix.fetch_starting_grid") as mock_grid,
+        patch("broiestbot.commands.f1.grandprix.fetch_race_winner_odds", return_value=RACE_WINNER_ODDS),
+    ):
+        result = f1_grand_prix_at(datetime(2026, 3, 4, 15, tzinfo=timezone.utc))
+
+    assert "NEXT UP: BAHRAIN GRAND PRIX" in result
+    assert "57 laps, 308.238 km" in result
+    assert "Sun Mar 8, 11:00am ET <i>(in 4 days)</i>" in result
+    assert "ODDS TO WIN" in result
+    assert result.index("Max Verstappen") < result.index("Lando Norris") < result.index("Charles Leclerc")
+    assert "🇬🇧 Lando Norris: <b>3.25</b>" in result
+    # Starting grids aren't published this far out, so don't bother asking for one.
+    mock_grid.assert_not_called()
+
+
+def test_upcoming_race_lists_starting_grid_after_qualifying(race_upcoming, starting_grid):
+    """Once qualifying is done, drivers are listed by grid position instead of odds."""
+    with (
+        patch("broiestbot.commands.f1.grandprix.fetch_season_races", return_value=[race_upcoming]),
+        patch("broiestbot.commands.f1.grandprix.fetch_starting_grid", return_value=starting_grid),
+        patch("broiestbot.commands.f1.grandprix.fetch_race_winner_odds") as mock_odds,
+    ):
+        result = f1_grand_prix_at(datetime(2026, 3, 7, 18, tzinfo=timezone.utc))
+
+    assert "NEXT UP: BAHRAIN GRAND PRIX" in result
+    assert "STARTING GRID" in result
+    assert "<b>P1</b> 🇳🇱 Max Verstappen <i>(Red Bull Racing)</i> 1:29.179" in result
+    assert "<b>P2</b> 🇩🇪 Nico Hulkenberg <i>(Audi)</i> 1:29.512" in result
+    assert "<b>P3</b> 🇯🇵 Yuki Tsunoda <i>(Racing Bulls)</i> 1:29.740" in result
+    assert "ODDS TO WIN" not in result
+    mock_odds.assert_not_called()
+
+
+def test_imminent_race_without_a_grid_lists_odds(race_upcoming):
+    """A race whose qualifying hasn't run yet still falls back to odds."""
+    with (
+        patch("broiestbot.commands.f1.grandprix.fetch_season_races", return_value=[race_upcoming]),
+        patch("broiestbot.commands.f1.grandprix.fetch_starting_grid", return_value=[]),
+        patch("broiestbot.commands.f1.grandprix.fetch_race_winner_odds", return_value=RACE_WINNER_ODDS),
+    ):
+        result = f1_grand_prix_at(datetime(2026, 3, 7, 18, tzinfo=timezone.utc))
+
+    assert "STARTING GRID" not in result
+    assert "ODDS TO WIN" in result
+
+
+def test_upcoming_race_without_odds_says_so(race_upcoming):
+    """A race with no odds available still reports the grand prix itself."""
+    with (
+        patch("broiestbot.commands.f1.grandprix.fetch_season_races", return_value=[race_upcoming]),
+        patch("broiestbot.commands.f1.grandprix.fetch_race_winner_odds", return_value=None),
+    ):
+        result = f1_grand_prix_at(datetime(2026, 3, 4, 15, tzinfo=timezone.utc))
+
+    assert "NEXT UP: BAHRAIN GRAND PRIX" in result
+    assert "no odds available" in result
+
+
+# ---------------------------------------------------------------------------
+# Offseason
+# ---------------------------------------------------------------------------
+
+
+def test_finished_season_reports_next_season_opener(race_completed, race_upcoming):
+    """Once every race has been run, the start of next season is reported."""
+    next_season_opener = {
+        **race_upcoming,
+        "id": 1201,
+        "season": 2027,
+        "competition": {"id": 22, "name": "Australia", "location": {"country": "Australia", "city": "Melbourne"}},
+        "date": "2027-03-07T05:00:00+00:00",
+    }
+    with patch(
+        "broiestbot.commands.f1.grandprix.fetch_season_races",
+        side_effect=[[race_completed], [next_season_opener, {**next_season_opener, "date": "2027-03-21T15:00:00Z"}]],
+    ):
+        result = f1_grand_prix_at(datetime(2026, 12, 20, tzinfo=timezone.utc))
+
+    assert "the 2026 F1 season is over" in result
+    assert "Australia Grand Prix" in result
+    assert "kicks off the 2027 season" in result
+    assert "Sun Mar 7, 12:00am ET" in result
+
+
+def test_finished_season_without_a_schedule(race_completed):
+    """An unannounced schedule for next season is reported as such."""
+    with patch(
+        "broiestbot.commands.f1.grandprix.fetch_season_races",
+        side_effect=[[race_completed], None],
+    ):
+        result = f1_grand_prix_at(datetime(2026, 12, 20, tzinfo=timezone.utc))
+
+    assert "the 2026 F1 season is over" in result
+    assert "the 2027 schedule hasn't been announced yet" in result
+
+
+def test_season_without_a_schedule_isnt_called_over():
+    """A season the API has no races for is reported as unscheduled rather than finished."""
+    with patch("broiestbot.commands.f1.grandprix.fetch_season_races", side_effect=[[], None]):
+        result = f1_grand_prix_at(datetime(2026, 1, 4, tzinfo=timezone.utc))
+
+    assert "no 2026 F1 races on the schedule" in result
+    assert "the 2027 schedule hasn't been announced yet" in result
+
+
+# ---------------------------------------------------------------------------
+# Failures
+# ---------------------------------------------------------------------------
+
+
+def test_failed_race_fetch_returns_error_message():
+    """A failed request for the season's races is reported to the room."""
+    with patch("broiestbot.commands.f1.grandprix.fetch_season_races", return_value=None):
+        assert f1_grand_prix_at(datetime(2026, 3, 4, tzinfo=timezone.utc)) == API_ERROR_MESSAGE
+
+
+def test_unexpected_error_returns_error_message(race_upcoming):
+    """Unexpected errors are swallowed & reported to the room."""
+    with (
+        patch("broiestbot.commands.f1.grandprix.fetch_season_races", return_value=[race_upcoming]),
+        patch("broiestbot.commands.f1.grandprix.fetch_race_winner_odds", side_effect=ValueError("boom")),
+    ):
+        assert f1_grand_prix_at(datetime(2026, 3, 4, tzinfo=timezone.utc)) == API_ERROR_MESSAGE

--- a/broiestbot/commands/f1/tests/test_odds.py
+++ b/broiestbot/commands/f1/tests/test_odds.py
@@ -1,0 +1,139 @@
+"""Tests for fetching bookmaker odds of drivers winning a grand prix."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from broiestbot.commands.f1 import odds as f1_odds
+from broiestbot.commands.f1.odds import (
+    _match_race_winner_market,
+    _parse_odds_from_market,
+    fetch_f1_sport_id,
+    fetch_race_winner_odds,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_cached_sport_id():
+    """Clear the cached F1 sport ID between tests."""
+    f1_odds._F1_SPORT_ID = None
+    yield
+    f1_odds._F1_SPORT_ID = None
+
+
+# ---------------------------------------------------------------------------
+# Sport ID lookup
+# ---------------------------------------------------------------------------
+
+
+def test_f1_sport_id_is_resolved_by_name(odds_sports):
+    """F1's ID is looked up by name rather than hardcoded, then cached."""
+    mock_resp = MagicMock(status_code=200)
+    mock_resp.json.return_value = {"sports": odds_sports}
+    with patch("broiestbot.commands.f1.odds.requests.get", return_value=mock_resp) as mock_get:
+        assert fetch_f1_sport_id() == 12
+        assert fetch_f1_sport_id() == 12
+    assert mock_get.call_count == 1
+
+
+def test_missing_f1_sport_id_returns_none():
+    """A bookmaker which doesn't offer F1 yields no sport ID."""
+    mock_resp = MagicMock(status_code=200)
+    mock_resp.json.return_value = {"sports": [{"id": 1, "name": "Soccer"}]}
+    with patch("broiestbot.commands.f1.odds.requests.get", return_value=mock_resp):
+        assert fetch_f1_sport_id() is None
+
+
+# ---------------------------------------------------------------------------
+# Market matching & parsing
+# ---------------------------------------------------------------------------
+
+
+def test_race_winner_market_is_matched_to_the_grand_prix(odds_specials, odds_race_winner_market, race_upcoming):
+    """The winner market naming the grand prix wins out over other outrights."""
+    assert _match_race_winner_market(odds_specials, race_upcoming) == odds_race_winner_market
+
+
+def test_unrelated_markets_are_ignored(race_upcoming):
+    """Markets which aren't about a winner are never matched."""
+    fastest_lap_market = {
+        "category": "Fastest Lap",
+        "name": "Bahrain Grand Prix - Fastest Lap",
+        "starts": "2026-03-08T15:00:00Z",
+        "lines": {"0": {"name": "Lando Norris", "price": 3.0}},
+    }
+    assert _match_race_winner_market([fastest_lap_market], race_upcoming) is None
+
+
+def test_nearest_winner_market_matched_when_grand_prix_isnt_named(race_upcoming):
+    """When no market names the grand prix, the one starting closest to it is used."""
+    next_race_market = {
+        "category": "Race Winner",
+        "name": "Race Winner",
+        "starts": "2026-03-22T15:00:00Z",
+        "lines": {"0": {"name": "Lando Norris", "price": 2.5}},
+    }
+    this_race_market = {
+        "category": "Race Winner",
+        "name": "Race Winner",
+        "starts": "2026-03-08T15:00:00Z",
+        "lines": {"0": {"name": "Max Verstappen", "price": 1.9}},
+    }
+    assert _match_race_winner_market([next_race_market, this_race_market], race_upcoming) == this_race_market
+
+
+def test_odds_are_sorted_by_favorite(odds_race_winner_market):
+    """Drivers are returned favorite-first, dropping any without a price."""
+    assert _parse_odds_from_market(odds_race_winner_market) == [
+        ("Max Verstappen", 1.72),
+        ("Lando Norris", 3.25),
+        ("Charles Leclerc", 4.5),
+    ]
+
+
+def test_odds_lines_parsed_from_a_list():
+    """Lines are parsed whether they arrive as a dict or a list."""
+    market = {"lines": [{"name": "Max Verstappen", "price": "1.72"}, {"name": "Broiestbot", "price": "not a price"}]}
+    assert _parse_odds_from_market(market) == [("Max Verstappen", 1.72)]
+
+
+def test_market_without_lines_has_no_odds():
+    """A market with no lines parses into no odds."""
+    assert _parse_odds_from_market({}) == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_race_winner_odds_are_fetched(odds_specials, race_upcoming):
+    """Odds for a race are looked up via the bookmaker's prematch outrights."""
+    with (
+        patch("broiestbot.commands.f1.odds.fetch_f1_sport_id", return_value=12),
+        patch("broiestbot.commands.f1.odds._fetch_odds_data", return_value=odds_specials) as mock_fetch,
+    ):
+        odds = fetch_race_winner_odds(race_upcoming)
+    assert odds[0] == ("Max Verstappen", 1.72)
+    assert mock_fetch.call_args.args[1]["event_type"] == "prematch"
+
+
+def test_live_odds_are_used_when_no_prematch_market_exists(odds_specials, race_upcoming):
+    """A live race falls back to the bookmaker's live outrights."""
+
+    def fake_fetch(_endpoint, params, _response_key):
+        return odds_specials if params["event_type"] == "live" else []
+
+    with (
+        patch("broiestbot.commands.f1.odds.fetch_f1_sport_id", return_value=12),
+        patch("broiestbot.commands.f1.odds._fetch_odds_data", side_effect=fake_fetch) as mock_fetch,
+    ):
+        odds = fetch_race_winner_odds(race_upcoming)
+    assert odds[0] == ("Max Verstappen", 1.72)
+    assert mock_fetch.call_count == 2
+
+
+def test_no_odds_without_a_sport_id(race_upcoming):
+    """Odds are skipped entirely when F1 isn't offered by the bookmaker."""
+    with patch("broiestbot.commands.f1.odds.fetch_f1_sport_id", return_value=None):
+        assert fetch_race_winner_odds(race_upcoming) is None

--- a/broiestbot/commands/f1/tests/test_races.py
+++ b/broiestbot/commands/f1/tests/test_races.py
@@ -1,0 +1,117 @@
+"""Tests for fetching & classifying F1 races."""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+from broiestbot.commands.f1.races import (
+    current_lap,
+    fetch_season_races,
+    find_live_race,
+    find_next_race,
+    is_race_abandoned,
+    is_race_finished,
+    is_race_live,
+)
+
+RACE_START = datetime(2026, 3, 8, 15, tzinfo=timezone.utc)
+
+# ---------------------------------------------------------------------------
+# Race state
+# ---------------------------------------------------------------------------
+
+
+def test_race_is_live_once_it_starts(race_live):
+    """A race which has started but isn't finished is live."""
+    assert is_race_live(race_live, datetime(2026, 3, 8, 16, tzinfo=timezone.utc)) is True
+
+
+def test_race_is_not_live_before_lights_out(race_live):
+    """A race which hasn't started yet isn't live."""
+    assert is_race_live(race_live, datetime(2026, 3, 8, 14, tzinfo=timezone.utc)) is False
+
+
+def test_race_is_not_live_long_after_it_started(race_live):
+    """A race which started well beyond its runtime is no longer considered live."""
+    assert is_race_live(race_live, datetime(2026, 3, 8, 23, tzinfo=timezone.utc)) is False
+
+
+def test_live_status_beats_the_clock(race_live):
+    """An explicitly live status is honored regardless of the scheduled start time."""
+    delayed_race = {**race_live, "status": "Live"}
+    assert is_race_live(delayed_race, datetime(2026, 3, 9, 12, tzinfo=timezone.utc)) is True
+
+
+def test_completed_and_cancelled_races_are_never_live(race_completed, race_cancelled):
+    """Finished & abandoned races are never reported as live."""
+    assert is_race_finished(race_completed) is True
+    assert is_race_abandoned(race_cancelled) is True
+    assert is_race_live(race_completed, datetime(2026, 3, 1, 6, tzinfo=timezone.utc)) is False
+    assert is_race_live(race_cancelled, datetime(2026, 3, 22, 16, tzinfo=timezone.utc)) is False
+
+
+def test_race_without_a_date_is_not_live(race_live):
+    """A race with no start time can't be judged as live."""
+    assert is_race_live({**race_live, "date": None}, RACE_START) is False
+
+
+# ---------------------------------------------------------------------------
+# Finding races within a season
+# ---------------------------------------------------------------------------
+
+
+def test_live_race_is_found_among_a_season(race_completed, race_live, race_cancelled):
+    """The race underway is picked out of a full season of races."""
+    races = [race_completed, race_live, race_cancelled]
+    assert find_live_race(races, datetime(2026, 3, 8, 16, tzinfo=timezone.utc)) == race_live
+
+
+def test_no_live_race_between_grand_prix(race_completed, race_upcoming):
+    """No race is live during the week between grands prix."""
+    assert find_live_race([race_completed, race_upcoming], datetime(2026, 3, 4, tzinfo=timezone.utc)) is None
+
+
+def test_next_race_is_the_soonest_scheduled_race(race_completed, race_upcoming, race_cancelled):
+    """The next race is the earliest unrun race, ignoring cancelled ones."""
+    later_race = {**race_upcoming, "id": 1150, "date": "2026-04-05T15:00:00+00:00"}
+    races = [later_race, race_completed, race_cancelled, race_upcoming]
+    assert find_next_race(races, datetime(2026, 3, 4, tzinfo=timezone.utc)) == race_upcoming
+
+
+def test_no_next_race_once_the_season_ends(race_completed):
+    """A season of finished races has no next race."""
+    assert find_next_race([race_completed], datetime(2026, 12, 20, tzinfo=timezone.utc)) is None
+
+
+def test_current_lap(race_live, race_upcoming):
+    """Laps are displayed as `current/total`, and omitted before a race starts."""
+    assert current_lap(race_live) == "32/57"
+    assert current_lap(race_upcoming) is None
+    assert current_lap({"laps": {"current": 12, "total": None}}) == "12"
+    assert current_lap({}) is None
+
+
+# ---------------------------------------------------------------------------
+# API requests
+# ---------------------------------------------------------------------------
+
+
+def test_season_races_are_unwrapped_from_response(race_upcoming):
+    """A 200 response returns the `response` array of races."""
+    mock_resp = MagicMock(status_code=200)
+    mock_resp.json.return_value = {"response": [race_upcoming]}
+    with patch("broiestbot.commands.f1.races.requests.get", return_value=mock_resp) as mock_get:
+        assert fetch_season_races(2026) == [race_upcoming]
+    assert mock_get.call_args.kwargs["params"] == {"season": 2026, "type": "Race", "timezone": "UTC"}
+
+
+def test_failed_race_request_returns_none():
+    """Non-200 responses are logged & swallowed."""
+    mock_resp = MagicMock(status_code=429, text="Too many requests")
+    with patch("broiestbot.commands.f1.races.requests.get", return_value=mock_resp):
+        assert fetch_season_races(2026) is None
+
+
+def test_race_request_exception_returns_none():
+    """Connection errors are logged & swallowed."""
+    with patch("broiestbot.commands.f1.races.requests.get", side_effect=TimeoutError("timed out")):
+        assert fetch_season_races(2026) is None

--- a/broiestbot/commands/f1/tests/test_util.py
+++ b/broiestbot/commands/f1/tests/test_util.py
@@ -1,0 +1,138 @@
+"""Tests for Formula 1 formatting helpers."""
+
+from datetime import datetime, timedelta, timezone
+
+from broiestbot.commands.f1.util import (
+    UNKNOWN_FLAG,
+    country_code_to_flag,
+    country_flag,
+    driver_flag,
+    driver_flag_from_name,
+    format_countdown,
+    format_odds,
+    format_race_date,
+    nationality_flag,
+    normalize_name,
+    parse_race_date,
+)
+from config import (
+    F1_COUNTRY_CODES,
+    F1_DRIVER_NATIONALITIES,
+    F1_NATIONALITY_COUNTRY_CODES,
+)
+
+# ---------------------------------------------------------------------------
+# Flags
+# ---------------------------------------------------------------------------
+
+
+def test_country_code_becomes_flag_emoji():
+    """Two-letter country codes are converted to regional indicator pairs."""
+    assert country_code_to_flag("NL") == "🇳🇱"
+    assert country_code_to_flag("gb") == "🇬🇧"
+
+
+def test_invalid_country_code_has_no_flag():
+    """Garbage country codes yield an empty string rather than mojibake."""
+    assert country_code_to_flag(None) == ""
+    assert country_code_to_flag("") == ""
+    assert country_code_to_flag("NLD") == ""
+    assert country_code_to_flag("N1") == ""
+
+
+def test_host_country_flag():
+    """Grand prix host countries are matched case-insensitively."""
+    assert country_flag("Bahrain") == "🇧🇭"
+    assert country_flag("united states") == "🇺🇸"
+    assert country_flag("Atlantis") == ""
+    assert country_flag(None) == ""
+
+
+def test_nationality_flag():
+    """Driver nationalities map to their country's flag."""
+    assert nationality_flag("Dutch") == "🇳🇱"
+    assert nationality_flag("monegasque") == "🇲🇨"
+    assert nationality_flag("Martian") == ""
+
+
+def test_driver_flag_prefers_stated_nationality():
+    """A driver's own nationality is used whenever the API provides one."""
+    assert driver_flag({"name": "Max Verstappen", "nationality": "Dutch"}) == "🇳🇱"
+
+
+def test_driver_flag_falls_back_to_surname():
+    """Responses without a nationality fall back to a lookup by surname."""
+    assert driver_flag({"name": "Charles Leclerc"}) == "🇲🇨"
+    assert driver_flag_from_name("L. Hamilton") == "🇬🇧"
+
+
+def test_driver_flag_ignores_accents():
+    """Accented surnames still match their nationality."""
+    assert driver_flag({"name": "Nico Hülkenberg"}) == "🇩🇪"
+    assert driver_flag({"name": "Sergio Pérez"}) == "🇲🇽"
+
+
+def test_unknown_driver_gets_placeholder_flag():
+    """Drivers of unknown nationality get a placeholder rather than no flag at all."""
+    assert driver_flag({"name": "Todd Birchard"}) == UNKNOWN_FLAG
+    assert driver_flag({}) == UNKNOWN_FLAG
+
+
+def test_configured_countries_all_have_valid_flags():
+    """Every configured country code resolves to a flag emoji."""
+    for country_code in {**F1_COUNTRY_CODES, **F1_NATIONALITY_COUNTRY_CODES}.values():
+        assert country_code_to_flag(country_code) != ""
+
+
+def test_configured_driver_nationalities_are_known():
+    """Every driver's fallback nationality has a country code to match."""
+    for nationality in F1_DRIVER_NATIONALITIES.values():
+        assert nationality_flag(nationality) != ""
+
+
+def test_names_are_normalized_for_comparison():
+    """Accents & casing are stripped when comparing names across data sources."""
+    assert normalize_name("Nico Hülkenberg") == "nico hulkenberg"
+    assert normalize_name(None) == ""
+
+
+# ---------------------------------------------------------------------------
+# Dates & odds
+# ---------------------------------------------------------------------------
+
+
+def test_race_dates_are_parsed_as_utc():
+    """ISO-8601 race dates are parsed, defaulting to UTC when no offset is given."""
+    assert parse_race_date("2026-03-08T15:00:00+00:00") == datetime(2026, 3, 8, 15, tzinfo=timezone.utc)
+    assert parse_race_date("2026-03-08T15:00:00Z") == datetime(2026, 3, 8, 15, tzinfo=timezone.utc)
+    assert parse_race_date("2026-03-08T15:00:00") == datetime(2026, 3, 8, 15, tzinfo=timezone.utc)
+
+
+def test_unparseable_race_dates_are_dropped():
+    """Missing or malformed race dates return None instead of raising."""
+    assert parse_race_date(None) is None
+    assert parse_race_date("next sunday") is None
+
+
+def test_race_dates_display_in_eastern_time():
+    """Race start times are displayed in US eastern time."""
+    assert format_race_date(datetime(2026, 3, 8, 15, tzinfo=timezone.utc)) == "Sun Mar 8, 11:00am ET"
+
+
+def test_countdown_scales_with_time_remaining():
+    """Countdowns are rounded to the largest sensible unit."""
+    assert format_countdown(timedelta(days=3, hours=2)) == "in 3 days"
+    assert format_countdown(timedelta(days=1)) == "in 1 day"
+    assert format_countdown(timedelta(hours=5)) == "in 5 hours"
+    assert format_countdown(timedelta(minutes=22)) == "in 22 minutes"
+    assert format_countdown(timedelta(seconds=30)) == "in 1 minute"
+    assert format_countdown(timedelta(seconds=-60)) == "any moment now"
+
+
+def test_odds_formatting():
+    """Decimal prices keep two decimals, including longshots."""
+    assert format_odds(1.7) == "1.70"
+    assert format_odds(26.0) == "26.00"
+    assert format_odds(2500) == "2500.00"
+    assert format_odds(-140) == "-140"
+    assert format_odds(None) == ""

--- a/broiestbot/commands/f1/util.py
+++ b/broiestbot/commands/f1/util.py
@@ -1,0 +1,172 @@
+"""Helpers for formatting Formula 1 data."""
+
+import unicodedata
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from emoji import emojize
+
+from config import (
+    F1_COUNTRY_CODES,
+    F1_DRIVER_NATIONALITIES,
+    F1_NATIONALITY_COUNTRY_CODES,
+    TIMEZONE_US_EASTERN,
+)
+
+# Shown in place of a flag when a driver's nationality can't be determined.
+UNKNOWN_FLAG = emojize(":globe_with_meridians:", language="en")
+
+
+def country_code_to_flag(country_code: Optional[str]) -> str:
+    """
+    Build a flag emoji from an ISO 3166-1 alpha-2 country code.
+
+    Flags are pairs of regional indicator symbols, which are offset from ASCII
+    uppercase letters by a fixed amount (`A` -> `U+1F1E6`).
+
+    :param Optional[str] country_code: Two-letter country code, ie: `NL`.
+
+    :returns: str
+    """
+    code = (country_code or "").strip().upper()
+    if len(code) != 2 or not code.isalpha():
+        return ""
+    return "".join(chr(0x1F1E6 + ord(char) - ord("A")) for char in code)
+
+
+def country_flag(country: Optional[str]) -> str:
+    """
+    Flag emoji of a grand prix' host country.
+
+    :param Optional[str] country: Country hosting a grand prix, ie: `Bahrain`.
+
+    :returns: str
+    """
+    if not country:
+        return ""
+    return country_code_to_flag(F1_COUNTRY_CODES.get(country.strip().title()))
+
+
+def nationality_flag(nationality: Optional[str]) -> str:
+    """
+    Flag emoji of a driver's nationality.
+
+    :param Optional[str] nationality: Nationality of a driver, ie: `Dutch`.
+
+    :returns: str
+    """
+    if not nationality:
+        return ""
+    return country_code_to_flag(F1_NATIONALITY_COUNTRY_CODES.get(nationality.strip().title()))
+
+
+def normalize_name(name: Optional[str]) -> str:
+    """
+    Strip accents & casing from a name to make it comparable across data sources.
+
+    :param Optional[str] name: Name of a driver, ie: `Nico Hülkenberg`.
+
+    :returns: str
+    """
+    if not name:
+        return ""
+    decomposed = unicodedata.normalize("NFKD", name)
+    return "".join(char for char in decomposed if not unicodedata.combining(char)).strip().lower()
+
+
+def driver_flag(driver: dict) -> str:
+    """
+    Flag emoji of a driver, either from their stated nationality or their surname.
+
+    :param dict driver: Driver object returned by the F1 API.
+
+    :returns: str
+    """
+    nationality = driver.get("nationality")
+    if not nationality:
+        surname = normalize_name(driver.get("name")).split(" ")[-1]
+        nationality = F1_DRIVER_NATIONALITIES.get(surname)
+    return nationality_flag(nationality) or UNKNOWN_FLAG
+
+
+def driver_flag_from_name(name: Optional[str]) -> str:
+    """
+    Flag emoji of a driver known only by name (ie: as named by a bookmaker).
+
+    :param Optional[str] name: Full or partial name of a driver.
+
+    :returns: str
+    """
+    return driver_flag({"name": name})
+
+
+def parse_race_date(race_date: Optional[str]) -> Optional[datetime]:
+    """
+    Parse a race's ISO-8601 start time into a timezone-aware datetime.
+
+    Races are always fetched in UTC, so times which arrive without an offset are assumed to be UTC.
+
+    :param Optional[str] race_date: Race start time, ie: `2026-03-08T15:00:00+00:00`.
+
+    :returns: Optional[datetime]
+    """
+    if not race_date:
+        return None
+    try:
+        parsed_date = datetime.fromisoformat(race_date.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed_date.tzinfo is None:
+        return parsed_date.replace(tzinfo=timezone.utc)
+    return parsed_date
+
+
+def format_race_date(start_time: datetime) -> str:
+    """
+    Display a race's start time in US eastern time.
+
+    :param datetime start_time: Start time of a race.
+
+    :returns: str
+    """
+    local_start_time = start_time.astimezone(TIMEZONE_US_EASTERN)
+    return local_start_time.strftime("%a %b %-d, %-I:%M%p").replace("AM", "am").replace("PM", "pm") + " ET"
+
+
+def format_countdown(time_remaining: timedelta) -> str:
+    """
+    Human-readable countdown until a race starts, ie: `in 3 days`.
+
+    :param timedelta time_remaining: Time between now and a race's start time.
+
+    :returns: str
+    """
+    seconds_remaining = int(time_remaining.total_seconds())
+    if seconds_remaining <= 0:
+        return "any moment now"
+    if seconds_remaining < 3600:
+        minutes = max(seconds_remaining // 60, 1)
+        return f"in {minutes} minute{'s' if minutes > 1 else ''}"
+    if seconds_remaining < 86400:
+        hours = seconds_remaining // 3600
+        return f"in {hours} hour{'s' if hours > 1 else ''}"
+    days = seconds_remaining // 86400
+    return f"in {days} day{'s' if days > 1 else ''}"
+
+
+def format_odds(price: Optional[float]) -> str:
+    """
+    Format a bookmaker's price for display.
+
+    Prices arrive as decimal odds (`1.72`), where longshots are simply large numbers.
+    Negative prices only occur in American odds, which are shown as-is.
+
+    :param Optional[float] price: Price of a driver winning.
+
+    :returns: str
+    """
+    if price is None:
+        return ""
+    if price < 0:
+        return f"{int(price)}"
+    return f"{price:.2f}"

--- a/config.py
+++ b/config.py
@@ -776,6 +776,151 @@ NBA_SEASON_YEAR = "2024-2025"
 SUMO_API_BASE_URL = "https://sumo-api.com/api"
 SUMO_DIVISION = "Makuuchi"
 
+# Formula 1
+# -------------------------------------------------
+F1_BASE_URL = "https://api-formula-1.p.rapidapi.com"
+F1_RACES_ENDPOINT = f"{F1_BASE_URL}/races"
+F1_RACE_RANKINGS_ENDPOINT = f"{F1_BASE_URL}/rankings/races"
+F1_STARTING_GRID_ENDPOINT = f"{F1_BASE_URL}/rankings/startinggrid"
+F1_HTTP_HEADERS = {
+    "content-type": "application/json",
+    "x-rapidapi-key": RAPID_API_KEY,
+    "x-rapidapi-host": "api-formula-1.p.rapidapi.com",
+}
+
+# Pinnacle "outright" markets, which is where race-winner odds live.
+F1_ODDS_SPORTS_ENDPOINT = "https://pinnacle-odds.p.rapidapi.com/kit/v1/sports"
+F1_ODDS_SPECIAL_MARKETS_ENDPOINT = "https://pinnacle-odds.p.rapidapi.com/kit/v1/special-markets"
+F1_ODDS_HTTP_HEADERS = {
+    "x-rapidapi-key": RAPID_API_KEY,
+    "x-rapidapi-host": "pinnacle-odds.p.rapidapi.com",
+}
+# Maximum number of drivers to list when displaying odds (a full grid, ignoring novelty lines).
+F1_ODDS_DRIVER_LIMIT = 20
+
+# A grand prix which started within this many hours is considered live (red flags & all).
+F1_RACE_LIVE_WINDOW_HOURS = 4
+# Starting grids are only published once qualifying has been run, roughly a day before a race.
+F1_QUALIFYING_LOOKAHEAD_HOURS = 48
+
+# Countries which host a grand prix, mapped to ISO 3166-1 alpha-2 codes (for flag emojis).
+F1_COUNTRY_CODES = {
+    "Australia": "AU",
+    "Austria": "AT",
+    "Azerbaijan": "AZ",
+    "Bahrain": "BH",
+    "Belgium": "BE",
+    "Brazil": "BR",
+    "Canada": "CA",
+    "China": "CN",
+    "France": "FR",
+    "Germany": "DE",
+    "Hungary": "HU",
+    "Italy": "IT",
+    "Japan": "JP",
+    "Madrid": "ES",
+    "Mexico": "MX",
+    "Monaco": "MC",
+    "Netherlands": "NL",
+    "Portugal": "PT",
+    "Qatar": "QA",
+    "Russia": "RU",
+    "Saudi Arabia": "SA",
+    "Singapore": "SG",
+    "South Korea": "KR",
+    "Spain": "ES",
+    "Turkey": "TR",
+    "UAE": "AE",
+    "USA": "US",
+    "United Arab Emirates": "AE",
+    "United Kingdom": "GB",
+    "United States": "US",
+    "United-States": "US",
+    "Vietnam": "VN",
+}
+
+# Driver nationalities as reported by the API, mapped to ISO 3166-1 alpha-2 codes.
+F1_NATIONALITY_COUNTRY_CODES = {
+    "American": "US",
+    "Argentine": "AR",
+    "Argentinian": "AR",
+    "Australian": "AU",
+    "Austrian": "AT",
+    "Belgian": "BE",
+    "Brazilian": "BR",
+    "British": "GB",
+    "Canadian": "CA",
+    "Chinese": "CN",
+    "Colombian": "CO",
+    "Czech": "CZ",
+    "Danish": "DK",
+    "Dutch": "NL",
+    "English": "GB",
+    "Estonian": "EE",
+    "Finnish": "FI",
+    "French": "FR",
+    "German": "DE",
+    "Hungarian": "HU",
+    "Indian": "IN",
+    "Indonesian": "ID",
+    "Irish": "IE",
+    "Israeli": "IL",
+    "Italian": "IT",
+    "Japanese": "JP",
+    "Malaysian": "MY",
+    "Mexican": "MX",
+    "Monegasque": "MC",
+    "New Zealander": "NZ",
+    "Norwegian": "NO",
+    "Polish": "PL",
+    "Portuguese": "PT",
+    "Russian": "RU",
+    "South African": "ZA",
+    "Spanish": "ES",
+    "Swedish": "SE",
+    "Swiss": "CH",
+    "Thai": "TH",
+    "Venezuelan": "VE",
+}
+
+# Fallback nationalities keyed by driver surname, used when a response omits `nationality`
+# (rankings, starting grids and bookmakers all return names without one).
+F1_DRIVER_NATIONALITIES = {
+    "albon": "Thai",
+    "alonso": "Spanish",
+    "antonelli": "Italian",
+    "bearman": "British",
+    "bortoleto": "Brazilian",
+    "bottas": "Finnish",
+    "colapinto": "Argentine",
+    "doohan": "Australian",
+    "gasly": "French",
+    "giovinazzi": "Italian",
+    "hadjar": "French",
+    "hamilton": "British",
+    "hulkenberg": "German",
+    "latifi": "Canadian",
+    "lawson": "New Zealander",
+    "leclerc": "Monegasque",
+    "lindblad": "British",
+    "magnussen": "Danish",
+    "norris": "British",
+    "ocon": "French",
+    "perez": "Mexican",
+    "piastri": "Australian",
+    "raikkonen": "Finnish",
+    "ricciardo": "Australian",
+    "russell": "British",
+    "sainz": "Spanish",
+    "sargeant": "American",
+    "schumacher": "German",
+    "stroll": "Canadian",
+    "tsunoda": "Japanese",
+    "verstappen": "Dutch",
+    "vettel": "German",
+    "zhou": "Chinese",
+}
+
 # Playstation PSN
 # -------------------------------------------------
 PLAYSTATION_SSO_TOKEN = getenv("PLAYSTATION_SSO_TOKEN")


### PR DESCRIPTION
Adds an `f1` command type which reports on F1 depending on where the
season currently stands:

* A live grand prix reports its current lap & the running order of every
  driver, falling back to odds when positions haven't been published yet.
* An imminent grand prix whose qualifying is complete lists every driver
  by grid position.
* An upcoming grand prix lists every driver by their bookmaker odds to
  win, sorted favorite-first.
* A finished season says so, along with the date of next season's opener.

Drivers are listed with a flag emoji of their nationality, built from ISO
3166-1 country codes so flags don't depend on emoji shortcode names.
Nationalities come from the API when present, otherwise from a surname
lookup in `config.py` (rankings, grids & bookmakers all omit them).

Races come from the Formula 1 API (`api-formula-1`), which the bot
already has RapidAPI credentials for. Race-winner odds come from the
Pinnacle outright ("special") markets, whose sport ID is resolved by name
at runtime rather than hardcoded.

Note: the `f1` command still needs a row in the `commands` table with
type `f1` before it can be triggered in chat.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AQySkhLH9KuoTpVxxEty7g